### PR TITLE
Reworked squidGuard fd's to use popen()

### DIFF
--- a/squidguard.c
+++ b/squidguard.c
@@ -8,66 +8,9 @@
 
 #include "openufp.h"
 
-int squidguard_getfd(FILE *sg_fd[2]) {
-    int outfd[2];
-    int infd[2];
+int squidguard_backend(char srcip[16], char srcusr[URL_SIZE], char url[URL_SIZE], char *sg_redirect, int debug) {
 
-    int oldstdin, oldstdout;
-
-    if (pipe(outfd) == -1) {
-        syslog(LOG_WARNING, "squidguard: pipe failed.");
-        return -1;
-    }
-    if (pipe(infd) == -1) {
-        syslog(LOG_WARNING, "squidguard: pipe failed.");
-        return -1;
-    }
-
-    oldstdin = dup(0);
-    oldstdout = dup(1);
-
-    close(0);
-    close(1);
-
-    dup2(outfd[0], 0);
-    dup2(infd[1], 1);
-
-    if (!fork()) {
-        char *argv[] = { "/usr/bin/squidGuard", 0 };
-
-        close(outfd[0]);
-        close(outfd[1]);
-        close(infd[0]);
-        close(infd[1]);
-        close(2);
-
-        if (execv(argv[0], argv) == -1) {
-            syslog(LOG_WARNING, "squidguard: failed executing /usr/bin/squidGuard.");
-            return -1;
-        }
-    } else {
-        close(0);
-        close(1);
-        dup2(oldstdin, 0);
-        dup2(oldstdout, 1);
-
-        close(outfd[0]);
-        close(infd[1]);
-
-        sg_fd[0] = fdopen(infd[0], "r");
-        sg_fd[1] = fdopen(outfd[1], "w");
-        return 0;
-    }
-    return 0;
-}
-
-int squidguard_closefd(FILE *sg_fd[2]) {
-    fclose(sg_fd[0]);
-    fclose(sg_fd[1]);
-    return 0;
-}
-
-int squidguard_backend(FILE *sg_fd[2], char srcip[16], char srcusr[URL_SIZE], char url[URL_SIZE], char *sg_redirect, int debug) {
+    FILE *sg_fd;
     char redirect_url[URL_SIZE];
 
     //Check user; if empty, use ip only:
@@ -83,33 +26,48 @@ int squidguard_backend(FILE *sg_fd[2], char srcip[16], char srcusr[URL_SIZE], ch
         syslog(LOG_INFO, "squidguard: url check using ip and user: ip: %s user: %s for url %s", srcip, srcusr, url);
     }
 
-    if (sg_fd[1] == NULL) {
-        syslog(LOG_WARNING, "squidguard: could not open fd for input.");
-        return 0;
+    //Updated fd management to popen():
+    char cmd[URL_SIZE];
+
+    snprintf(cmd, URL_SIZE, "echo '%s %s/ - - GET' | /usr/bin/squidGuard", url, srcip);
+    sg_fd = popen(cmd, "r");
+
+    if (sg_fd == NULL)
+    {
+        syslog(LOG_WARNING, "squidguard: couldn't popen() for output. Verify squidGuard: /usr/bin/squidGuard");
+	return 0;
     }
 
-    fprintf(sg_fd[1], "%s %s/ %s - GET\n", url, srcip, srcusr);
-    fflush(sg_fd[1]);
+    while (fgets(redirect_url, URL_SIZE, sg_fd) != NULL)
+    {
+        int rl = 0;
+        rl = strlen(redirect_url);
 
-    if (sg_fd[0] == NULL) {
-        syslog(LOG_WARNING, "squidguard: could not open fd for output.");
-        return 0;
-    }
-    while (fgets(redirect_url, URL_SIZE, sg_fd[0]) != NULL) {
-        if (strlen(redirect_url) > 2) {
+        if (debug > 2)
+        {
+            syslog(LOG_INFO, "squidguard: redirect_url length: %d, post fgets: %s", rl, redirect_url );
+        }
+
+        if (rl > 2)
+        {
             char *parse;
-            parse = strtok (redirect_url, " ");
+            parse = strtok (redirect_url, " \t");
             strcpy(sg_redirect, parse);
 
             if (debug > 0)
-                syslog(LOG_INFO, "squidguard: url blocked. parsed_red: %s -- sg_redirectURL: %s", parse, sg_redirect );
+                syslog(LOG_INFO, "squidguard: url blocked. parsed_redirect: %s, sg_redirectURL: %s", parse, sg_redirect );
 
+	    pclose(sg_fd);
             return 1;
         }
         if (debug > 0)
             syslog(LOG_INFO, "squidguard: url accepted.");
+
+	pclose(sg_fd);
         return 0;
+
     }
+    pclose(sg_fd);
     return 0;
 }
 

--- a/squidguard.h
+++ b/squidguard.h
@@ -6,6 +6,5 @@
  * squidguard.h: squidguard backend
  */
 
-extern int squidguard_getfd(FILE *sg_fd[2]);
-extern int squidguard_closefd(FILE *sg_fd[2]);
-extern int squidguard_backend(FILE *sg_fd[2], char srcip[16], char srcusr[URL_SIZE], char url[URL_SIZE], char *sg_redirect, int debug);
+extern int squidguard_closefd(FILE *sg_fd);
+extern int squidguard_backend(char srcip[16], char srcusr[URL_SIZE], char url[URL_SIZE], char *sg_redirect, int debug);


### PR DESCRIPTION
Removed existing functions related to file descriptor handling and replaced entirely with popen() calls, all within sg_backend calls.